### PR TITLE
Created vertical padding for home image

### DIFF
--- a/frontend/src/styles/Home.css
+++ b/frontend/src/styles/Home.css
@@ -22,3 +22,14 @@
     background-color: #b85f99 !important; /* Darker pink on hover */
     color: #fff !important;
 }
+
+/* Add vertical padding for images on mobile */
+@media (max-width: 768px) {
+    .split-col {
+        margin-bottom: 2rem;
+    }
+    
+    .split-col img {
+        margin-bottom: 1rem;
+    }
+}


### PR DESCRIPTION
# Add Vertical Padding for Home Images on Mobile View

## Description
This PR addresses issue #8 by adding proper vertical spacing for the home page images when viewed on mobile devices. Currently, the images stack without adequate spacing on mobile views, making the layout appear cramped and unprofessional.

## Changes Made
- Added responsive CSS rules in `Home.css` to create proper vertical spacing for images on mobile devices
- Implemented a media query for screens with max-width of 768px
- Added `margin-bottom: 2rem` to `.split-col` class for column spacing
- Added `margin-bottom: 1rem` to images for additional vertical padding

## Related Issues
Closes #8