### PR TITLE
feat(menu): Expand dessert menu

### DIFF
--- a/frontend/src/components/MenuItem.js
+++ b/frontend/src/components/MenuItem.js
@@ -1,0 +1,21 @@
+import React from 'react';
+import { Card } from 'react-bootstrap';
+
+const MenuItem = ({ name, description, price, category }) => {
+  return (
+    <Card className="h-100 menu-item" style={{ backgroundColor: '#1a1a1a', border: '1px solid #78133c' }}>
+      <Card.Body className="text-light">
+        <Card.Title className="d-flex justify-content-between align-items-center">
+          <span>{name}</span>
+          <span className="text-warning">${price}</span>
+        </Card.Title>
+        <Card.Text className="text-muted">{description}</Card.Text>
+        <div className="text-end">
+          <small className="text-warning">{category}</small>
+        </div>
+      </Card.Body>
+    </Card>
+  );
+};
+
+export default MenuItem;

--- a/frontend/src/pages/Menu.js
+++ b/frontend/src/pages/Menu.js
@@ -1,10 +1,96 @@
 import React from 'react';
+import { Container, Row, Col } from 'react-bootstrap';
+import MenuItem from '../components/MenuItem';
+import '../styles/Menu.css';
 
 const Menu = () => {
+  const desserts = [
+    {
+      name: "Tiramisu Classico",
+      description: "Traditional tiramisu with layers of coffee-soaked ladyfingers and mascarpone cream",
+      price: "12.99",
+      category: "Dessert"
+    },
+    {
+      name: "Panna Cotta ai Frutti di Bosco",
+      description: "Silky vanilla panna cotta topped with mixed berry compote",
+      price: "11.99",
+      category: "Dessert"
+    },
+    {
+      name: "Cannoli Siciliani",
+      description: "Crispy pastry tubes filled with sweet ricotta and chocolate chips, dusted with powdered sugar",
+      price: "10.99",
+      category: "Dessert"
+    },
+    {
+      name: "Torta al Cioccolato",
+      description: "Warm chocolate cake with molten center, served with vanilla gelato",
+      price: "13.99",
+      category: "Dessert"
+    },
+    {
+      name: "Gelato Trio",
+      description: "Choose any three: Vanilla, Chocolate, Pistachio, Stracciatella, Hazelnut, or Coffee",
+      price: "9.99",
+      category: "Ice Cream"
+    },
+    {
+      name: "Affogato al Caffè",
+      description: "Vanilla gelato 'drowned' in hot espresso with chocolate shavings",
+      price: "8.99",
+      category: "Ice Cream"
+    },
+    {
+      name: "Tartufo al Cioccolato",
+      description: "Chocolate and vanilla gelato with a cherry center, coated in cocoa powder",
+      price: "11.99",
+      category: "Ice Cream"
+    },
+    {
+      name: "Zeppole di San Giuseppe",
+      description: "Italian cream puffs filled with custard and topped with amarena cherries",
+      price: "10.99",
+      category: "Dessert"
+    },
+    {
+      name: "Semifreddo all'Amaretto",
+      description: "Semi-frozen amaretto-flavored dessert with caramelized almonds",
+      price: "11.99",
+      category: "Ice Cream"
+    },
+    {
+      name: "Crostata di Frutta",
+      description: "Fresh fruit tart with pastry cream and seasonal berries",
+      price: "12.99",
+      category: "Dessert"
+    },
+    {
+      name: "Profiteroles al Cioccolato",
+      description: "Choux pastry puffs filled with vanilla cream, drizzled with warm chocolate sauce",
+      price: "11.99",
+      category: "Dessert"
+    },
+    {
+      name: "Coppa Spagnola",
+      description: "Layers of vanilla and amarena cherry gelato with cherry sauce and whipped cream",
+      price: "10.99",
+      category: "Ice Cream"
+    }
+  ];
+
   return (
-    <div className="container mt-5">
-      <h1>Menu</h1>
-      <p>Explore our delicious food and drink options.</p>
+    <div className="py-5" style={{ backgroundColor: '#78133c', minHeight: '100vh' }}>
+      <Container>
+        <h1 className="text-center text-light mb-5">Dessert Menu</h1>
+        <Row xs={1} md={2} lg={3} className="g-4">
+          {desserts.map((item, idx) => (
+            <Col key={idx}>
+              <MenuItem {...item} />
+            </Col>
+          ))}
+        </Row>
+      </Container>
     </div>
   );
 };

--- a/frontend/src/styles/Menu.css
+++ b/frontend/src/styles/Menu.css
@@ -1,0 +1,36 @@
+.menu-item {
+  transition: transform 0.2s ease-in-out;
+}
+
+.menu-item:hover {
+  transform: translateY(-5px);
+}
+
+.menu-item .card-title {
+  font-size: 1.25rem;
+  font-weight: 600;
+}
+
+.menu-item .card-text {
+  font-size: 0.9rem;
+  line-height: 1.5;
+}
+
+.menu-item .text-warning {
+  color: #ffc107 !important;
+}
+
+/* Responsive adjustments */
+@media (max-width: 768px) {
+  .menu-item {
+    margin-bottom: 1rem;
+  }
+  
+  .menu-item .card-title {
+    font-size: 1.1rem;
+  }
+  
+  .menu-item .card-text {
+    font-size: 0.85rem;
+  }
+} 


### PR DESCRIPTION
📝 Pull Request Description:

Closes #16

This PR significantly expands and enhances the dessert menu displayed by the Menu component. The menu now includes 12 authentic Italian desserts, showcasing a well-balanced variety of traditional and gelato-based options.

🔧 Technical Notes:
Component was simplified to exclusively render the dessert category
All data structured for scalability and easy future additions